### PR TITLE
fix(Icon): base container alignment on custom size value

### DIFF
--- a/packages/bee-q/src/components/icon/bq-icon.tsx
+++ b/packages/bee-q/src/components/icon/bq-icon.tsx
@@ -109,7 +109,7 @@ export class BqIcon {
     return (
       <Host style={styles}>
         <div
-          class="h-[var(--bq-icon--size)] w-[var(--bq-icon--size)] text-[color:var(--bq-icon--color)]"
+          class="flex h-[var(--bq-icon--size)] w-[var(--bq-icon--size)] text-[color:var(--bq-icon--color)]"
           innerHTML={this._svgContent}
           part="base"
           role="img"


### PR DESCRIPTION
This fixes an issue where the SVG icon used inside the `bq-icon` is not centered within its container when a custom size value is used.

![image](https://user-images.githubusercontent.com/328492/223731909-8a837d0f-be75-4a24-9eef-0a92c95cc23b.png)
