### PR TITLE
fix(Slider): layout styles break if parent have alignment

### DIFF
--- a/packages/bee-q/src/components/slider/scss/bq-slider.scss
+++ b/packages/bee-q/src/components/slider/scss/bq-slider.scss
@@ -25,11 +25,11 @@
 }
 
 :host {
-  @apply block;
+  @apply block w-full;
 }
 
 .bq-slider {
-  @apply flex h-[calc(var(--bq-slider--thumb-size)_+_var(--bq-slider--size))] w-full items-center;
+  @apply flex h-[calc(var(--bq-slider--thumb-size)_+_var(--bq-slider--size))] w-full items-center text-start;
 }
 
 .bq-slider__container {


### PR DESCRIPTION
This fixes the issue where the `bq-slider` styles break when the parent container applies a display or text alignment CSS rule.

![image](https://user-images.githubusercontent.com/328492/223757710-011d4fbd-c2c8-48d7-99ed-d99dc7661c89.png)
