### PR TITLE
fix(Checkbox):  label miss-alignment if parent has different alignment

### DIFF
--- a/packages/bee-q/src/components/checkbox/bq-checkbox.tsx
+++ b/packages/bee-q/src/components/checkbox/bq-checkbox.tsx
@@ -244,7 +244,7 @@ export class BqCheckbox {
             )}
           </span>
         </div>
-        <span class="bq-checkbox__label ml-1 font-medium leading-large text-text-primary" part="label">
+        <span class="bq-checkbox__label ml-1 text-start font-medium leading-large text-text-primary" part="label">
           <slot />
         </span>
       </label>


### PR DESCRIPTION
This fixes the issue where the checkbox label gets separated from the checkbox square when the parent has a different text alignment.

![image](https://user-images.githubusercontent.com/328492/223765906-2a83221b-3684-4326-85e5-c5be51f465db.png)
