### PR TITLE
chore(VSCode): use `CSS Variable Autocomplete` extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -13,11 +13,11 @@
     "ms-vsliveshare.vsliveshare",
     "nrwl.angular-console",
     "oouo-diogo-perdigao.docthis",
-    "phoenisx.cssvar",
     "runem.lit-plugin",
     "sonarsource.sonarlint-vscode",
     "stackbreak.comment-divider",
     "stylelint.vscode-stylelint",
-    "zignd.html-css-class-completion"
+    "zignd.html-css-class-completion",
+    "vunguyentuan.vscode-css-variables"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,12 @@
   "[html]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "cssVariables.blacklistFolders": [
+    "dist",
+    "node_modules",
+    "out-tsc",
+    "tmp",
+  ],
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },


### PR DESCRIPTION
This [CSS Variable Autocomplete](https://marketplace.visualstudio.com/items?itemName=vunguyentuan.vscode-css-variables) will replace the use of the [CSS Var Complete](https://marketplace.visualstudio.com/items?itemName=phoenisx.cssvar) extension.