### PR TITLE
fix(angular wrapper): cannot mix multi and regular providers

### DIFF
--- a/packages/bee-q-angular/src/bee-q.module.ts
+++ b/packages/bee-q-angular/src/bee-q.module.ts
@@ -14,6 +14,7 @@ import { DIRECTIVES } from './directives';
       useFactory: () => {
         return defineCustomElements();
       },
+      multi: true,
     },
   ],
 })


### PR DESCRIPTION
It should fix the following issue:

![CleanShot 2023-06-23 at 12 20 10](https://github.com/Endava/bee-q/assets/328492/1879a748-28f3-4a76-a48d-50c2bf15617c)

We tell Angular that the provider is a multi-provider.