### PR TITLE
fix(Avatar): trim initials text only if exist

### DIFF
--- a/packages/bee-q/src/_storybook/foundation/typography.mdx
+++ b/packages/bee-q/src/_storybook/foundation/typography.mdx
@@ -58,7 +58,7 @@ To use the display font, add the `display` class to the element (recommended to 
 
 <Source dark format="dedent" language="html" code={`<h1 class="display">${SampleText}</h1>`} />
 
-<div class="rounded-xs border border-solid border-stroke-success bg-ui-success-light p-m">
+<div className="rounded-xs border border-solid border-stroke-success bg-ui-success-light p-m">
 **💡 NOTE:**
 
 In addition to the `.display` class, you can also add the `.semibold` or `.bold` classes to change the font weight of the text.
@@ -274,7 +274,7 @@ or the `.h6` class:
 
 The body text is used for the main content of a page, and should be visually distinct from other headings on the page.
 
-<div class="rounded-xs border border-solid border-stroke-warning bg-ui-warning-light p-m">
+<div className="rounded-xs border border-solid border-stroke-warning bg-ui-warning-light p-m">
   ❗️ BEEQ set by default the body styles in the global CSS, so **you don't need to add any class to use it**.
 </div>
 

--- a/packages/bee-q/src/components/avatar/bq-avatar.tsx
+++ b/packages/bee-q/src/components/avatar/bq-avatar.tsx
@@ -173,9 +173,9 @@ export class BqAvatar {
         <div
           class={{
             'absolute flex items-center justify-center': true,
-            'left-[var(--bq-avatar--badge-left-square)] top-[var(--bq-avatar--badge-top-square)]':
+            'start-[var(--bq-avatar--badge-left-square)] top-[var(--bq-avatar--badge-top-square)]':
               this.shape === 'square',
-            'left-[var(--bq-avatar--badge-left-circle)] top-[var(--bq-avatar--badge-top-circle)]':
+            'start-[var(--bq-avatar--badge-left-circle)] top-[var(--bq-avatar--badge-top-circle)]':
               this.shape === 'circle',
           }}
         >

--- a/packages/bee-q/src/components/avatar/bq-avatar.tsx
+++ b/packages/bee-q/src/components/avatar/bq-avatar.tsx
@@ -118,17 +118,13 @@ export class BqAvatar {
   };
 
   private getIndex = (size: TAvatarSize): number => {
-    switch (size) {
-      case 'small':
-        return 2;
-      case 'medium':
-        return 3;
-      case 'large':
-        return 4;
-      default:
-        // also if size === xsmall
-        return 1;
-    }
+    const sizeIndexMap = {
+      xsmall: 1,
+      small: 2,
+      medium: 3,
+      large: 4,
+    };
+    return sizeIndexMap[size] || sizeIndexMap.xsmall;
   };
 
   // render() function

--- a/packages/bee-q/src/components/avatar/bq-avatar.tsx
+++ b/packages/bee-q/src/components/avatar/bq-avatar.tsx
@@ -124,7 +124,7 @@ export class BqAvatar {
       medium: 3,
       large: 4,
     };
-    return sizeIndexMap[size] || sizeIndexMap.xsmall;
+    return sizeIndexMap[size] ?? sizeIndexMap.xsmall;
   };
 
   // render() function

--- a/packages/bee-q/src/components/avatar/bq-avatar.tsx
+++ b/packages/bee-q/src/components/avatar/bq-avatar.tsx
@@ -108,6 +108,8 @@ export class BqAvatar {
   };
 
   private trimInitialsBasedOnSize = (): void => {
+    if (!this.initials) return;
+
     AVATAR_SIZE.forEach((size: TAvatarSize) => {
       if (this.size === size) {
         this.trimmedInitials = this.initials.substring(0, this.getIndex(size));


### PR DESCRIPTION
When rendering an image Avatar (no initials text has been provided), we get the following error in the browser console:

![CleanShot 2023-08-08 at 11 34 03](https://github.com/Endava/bee-q/assets/328492/6c35f79a-3634-43cb-ba87-cb7bf802a8e8)

This PR will also improve the following:
- Use CSS logical properties for badge position, this will make the avatar + badge work as expected in the RTL content direction.
- Refactor `getIndex()` method to use object mapping instead of a Switch statement.